### PR TITLE
Make the symbol global to avoid version incompat

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,1 +1,1 @@
-module.exports = Symbol('util.inspect.custom')
+module.exports = Symbol.for('util.inspect.custom')

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 var util = require('util')
 var custom = util.inspect.custom
 
-module.exports = custom || Symbol('util.inspect.custom')
+module.exports = custom || Symbol.for('util.inspect.custom')


### PR DESCRIPTION
Using `Symbol.for` makes the symbol globally available, meaning multiple instances of this module will resolve to the same symbol